### PR TITLE
Bump brace-expansion to v1.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@ons/design-system": "^72.10.9",
     "@ons/prototype-kit": "git+https://github.com/ONSdigital/prototype-kit#v1.0.10",
     "axios": "^1.11.0",
+    "brace-expansion": "1.1.12",
     "chokidar": "4.0.3",
     "css-select": "6.0.0",
     "engine.io": "6.6.4",
@@ -34,6 +35,7 @@
     "micromatch": "4.0.8",
     "chokidar": "4.0.3",
     "css-select": "6.0.0",
-    "postcss": "8.5.6"
+    "postcss": "8.5.6",
+    "brace-expansion": "1.1.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1087,20 +1087,13 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+brace-expansion@1.1.12, brace-expansion@^1.1.7, brace-expansion@^2.0.1:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
+  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
 
 braces@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
### What is the context of this PR?

brace-expansion Regular Expression Denial of Service vulnerability

Bumping brace-expansion to v1.1.12 to fix vulnerability

### How to review this PR

Check vulnerable versions (>= 1.0.0, <= 1.1.11) are not being used
